### PR TITLE
Removed nitro emoji TODO

### DIFF
--- a/automoji.py
+++ b/automoji.py
@@ -93,15 +93,12 @@ class Automoji(commands.Bot):
 	
 
 	# Determines if 'arg' is a valid emoji.
-	# A valid emoji can be: (1) unicode, (2) custom to the current guild, or (3) custom to a guild 
-	# outside the current one (e.g. Discord Nitro).
+	# A valid emoji can be: (1) unicode, (2) custom to the current guild
 	def is_emoji(self, guild: discord.Guild, arg: str):
 		# (1) Unicode emojis
 		if emoji.emoji_count(arg) == 1: return True
 
 		# (2) Custom emojis in the current guild
 		if (guild != None) and (any(arg == str(em) for em in guild.emojis)): return True
-
-		# TODO: (3) Custom emojis to a guild outside the current one
 
 		return False

--- a/cogs/user_emojis.py
+++ b/cogs/user_emojis.py
@@ -35,6 +35,7 @@ class UserEmojis(commands.Cog, name="User Emojis", command_attrs=dict(ignore_ext
 		- You don't pass anything.
 		- You pass more than one emoji.
 		- You pass something other than an emoji.
+        - You pass an emoji from another server
 		- There's already an emoji assigned to you.
 
 		* This is a SERVER-ONLY command.

--- a/cogs/user_emojis.py
+++ b/cogs/user_emojis.py
@@ -35,7 +35,7 @@ class UserEmojis(commands.Cog, name="User Emojis", command_attrs=dict(ignore_ext
 		- You don't pass anything.
 		- You pass more than one emoji.
 		- You pass something other than an emoji.
-        - You pass an emoji from another server
+		- You pass an emoji from another server
 		- There's already an emoji assigned to you.
 
 		* This is a SERVER-ONLY command.


### PR DESCRIPTION
Removes TODO for functionality with emojis from other servers due to limitations of discord bot functionality.